### PR TITLE
Tileset-level custom property support

### DIFF
--- a/src/modules/graphics/Sprite/SpriteAtlas.cs
+++ b/src/modules/graphics/Sprite/SpriteAtlas.cs
@@ -58,34 +58,7 @@ namespace Ladybug.Graphics
 		/// Returns a <see cref="Sprite"/> stored in this SpriteAtlas
 		/// </summary>
 		/// <value></value>
-		public Sprite this[int i]
-		{
-			get
-			{
-				/*
-				var row = 0;
-				var col = 0;
-
-				if (i >= 0 && i <= (_rows * _cols) - 1)
-				{
-					row = (int)((float)i / (float)(_cols));
-					col = i % _cols;
-				}
-				*/
-				/*
-				Rectangle frame = new Rectangle(
-					(int)(SpriteWidth * col),
-					(int)(SpriteHeight * row),
-					(int)(SpriteWidth),
-					(int)(SpriteHeight)
-				);
-
-				return new Sprite(_sourceTexture, frame);
-				*/
-				//return this[col, row];
-				return this[Index2Coord(i)];
-			}
-		}
+		public Sprite this[int i] => this[Index2Coord(i)];
 
 		/// <summary>
 		/// Returns a <see cref="Sprite"/> stored in this SpriteAtlas

--- a/src/modules/tiles/Tile.cs
+++ b/src/modules/tiles/Tile.cs
@@ -1,0 +1,31 @@
+using System.Xml;
+
+using Ladybug.Graphics;
+
+namespace Ladybug.Tiles
+{
+	/// <summary>
+	/// A single tilemap tile
+	/// </summary>
+	public class Tile
+	{
+		internal Tile()
+		{
+
+		}
+
+		/// <summary>
+		/// Tile's sprite to be rendered upon drawing
+		/// </summary>
+		/// <value></value>
+		public Sprite Sprite { get; internal set; }
+
+		/// <summary>
+		/// XmlElement containing any custom properties and sub-objects of the tile
+		/// </summary>
+		/// <remarks>
+		/// Null if no custom tile properties have been defined for this tile
+		/// </remarks>
+		public XmlElement XmlElement { get; internal set; }
+	}
+}

--- a/src/modules/tiles/TileLayer.cs
+++ b/src/modules/tiles/TileLayer.cs
@@ -32,7 +32,7 @@ namespace Ladybug.Tiles
 			{
 				foreach (XmlElement prop in propNode.SelectNodes("./property"))
 				{
-					Properties.TryAdd(node.Attributes["name"].Value, node.Attributes["value"].Value);
+					Properties.TryAdd(prop.Attributes["name"].Value, prop.Attributes["value"].Value);
 					BuildCustomProperty(prop);
 				}
 			}
@@ -114,14 +114,14 @@ namespace Ladybug.Tiles
 						var pos = GetTilePosition(col, row);
 
 						spriteBatch.Draw(
-							tile.Texture,
+							tile.Sprite.Texture,
 							new Rectangle(
 								(int)pos.X,
 								(int)pos.Y,
 								tileSet.TileWidth,
 								tileSet.TileHeight
 							),
-							tile.Frame,
+							tile.Sprite.Frame,
 							Color.White
 						);
 					}

--- a/src/modules/tiles/TileMap.cs
+++ b/src/modules/tiles/TileMap.cs
@@ -265,6 +265,17 @@ namespace Ladybug.Tiles
 		}
 
 		/// <summary>
+		/// Handle the process of building a tile
+		/// </summary>
+		/// <param name="tile"></param>
+		protected virtual void BuildTile(Tile tile)
+		{
+			// To be overridden by derived classes
+		}
+
+		internal void _BuildTile(Tile tile) => BuildTile(tile);
+
+		/// <summary>
 		/// Handle the process of building an object
 		/// </summary>
 		/// <param name="layerNode"></param>

--- a/src/modules/tiles/TileSet.cs
+++ b/src/modules/tiles/TileSet.cs
@@ -32,14 +32,26 @@ namespace Ladybug.Tiles
 		}
 
 		/// <summary>
-		/// Access this TileSet's SpriteAtlas content by index
+		/// Access a tile defined as part of thils tileset by its index
 		/// </summary>
-		public Sprite this[int i] => SpriteAtlas[i];
+		public Tile this[int i] => this[Index2Coord(i)];
 
 		/// <summary>
-		/// Access this TileSet's SpriteAtlas content by coordinate
+		/// Access a tile defined as part of this tileset by its coordinate position
+		/// within the tileset
 		/// </summary>
-		public Sprite this[int i, int j] => SpriteAtlas[i, j];
+		public Tile this[int i, int j] => Tiles[i, j];
+
+		/// <summary>
+		/// Access a tile defined as part of this tileset by its coordinate position
+		/// within the tileset
+		/// </summary>
+		public Tile this[Vector2 v] => this[(int)v.X, (int)v.Y];
+
+		/// <summary>
+		/// Tiles defined as part of this tileset
+		/// </summary>
+		public Tile[,] Tiles { get; private set; }
 
 		/// <summary>
 		/// The ID of the first Tile in this TileSet
@@ -158,6 +170,7 @@ namespace Ladybug.Tiles
 			);
 
 			BuildAtlas(imagePath);
+			BuildTiles();
 		}
 
 		private void BuildAtlas(string imagePath)
@@ -168,6 +181,45 @@ namespace Ladybug.Tiles
 			// tilesets with spacing set won't look right until
 			// we get this addressed.
 			SpriteAtlas = new SpriteAtlas(tex, ColumnCount, RowCount);
+		}
+
+		private void BuildTiles()
+		{
+			Tiles = new Tile[ColumnCount, RowCount];
+			var currentTileID = 0;
+			for (var r = 0; r < RowCount; r++)
+			{
+				for (var c = 0; c < ColumnCount; c++)
+				{
+					var tile = new Tile()
+					{
+						Sprite = SpriteAtlas[c, r],
+						XmlElement = GetTileXml(currentTileID)
+					};
+					Tiles[c, r] = tile;
+					TileMap._BuildTile(tile);
+					currentTileID++;
+				}
+			}
+		}
+
+		private XmlElement GetTileXml(int tileID)
+		{
+			return XmlDocument.SelectSingleNode($"./tileset/tile[@id='{tileID}']") as XmlElement;
+		}
+
+		private Vector2 Index2Coord(int index)
+		{
+			var row = 0;
+			var col = 0;
+
+			if (index >= 0 && index <= (RowCount * ColumnCount) - 1)
+			{
+				row = (int)((float)index / (float)(ColumnCount));
+				col = index % ColumnCount;
+			}
+
+			return new Vector2(col, row);
 		}
 	}
 }


### PR DESCRIPTION
This changeset introduces the Tile class, and a new virtual lifecycle method `TileMap.BuildTile` which can be used to access custom tile-level properties including custom properties and collider data.

This changeset also fixes a bug with custom tile-layer properties and cleans up some vestigial commented-out code to improve readability in the SpriteAtlas class.